### PR TITLE
linux: Support non-usrmerged Debian/Ubuntu systems as well

### DIFF
--- a/contrib/debian/intan-rhx.install
+++ b/contrib/debian/intan-rhx.install
@@ -4,5 +4,5 @@ contrib/com.intantech.intan_rhx.desktop usr/share/applications/
 contrib/com.intantech.intan_rhx.metainfo.xml usr/share/metainfo
 images/intan-rhx.svg usr/share/icons/hicolor/scalable/apps/
 kernel.cl usr/lib/intan-rhx/
-libraries/Linux/60-opalkelly.rules usr/lib/udev/rules.d/
+libraries/Linux/60-opalkelly.rules lib/udev/rules.d/
 libraries/Linux/libokFrontPanel.so usr/lib/intan-rhx/


### PR DESCRIPTION
Hi!
I made a mistake in the previous packaging in assuming *all* systems installing this package are usrmerged (system data is only in /usr, you can read more about this [here](https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/)). This is not the case, but apart from that, not installing the udev rules to the right place messes with dpkg's tracking of directory ownership.

With this change, the resulting package should work well on both kinds of systems.
Cheers,
    Matthias
